### PR TITLE
Improve search of plugin scripts

### DIFF
--- a/kymsu.sh
+++ b/kymsu.sh
@@ -3,9 +3,4 @@ echo "Please, grab a ☕️ , KYMSU keep your working environment up to date!"
 echo "=============================================================="
 echo ""
 
-CLEANUP_ARG=${1:no-cleanup}
-
-for f in `ls ~/.kymsu/plugins.d/*.sh`;
-do
-  bash $f $CLEANUP_ARG
-done
+[ -d ~/.kymsu/plugins.d -a -x ~/.kymsu/plugins.d ] && find ~/.kymsu/plugins.d -type f -name '*.sh' -perm +u+x -exec $SHELL {} ${1:no-cleanup} \;

--- a/kymsu.sh
+++ b/kymsu.sh
@@ -3,4 +3,4 @@ echo "Please, grab a ☕️ , KYMSU keep your working environment up to date!"
 echo "=============================================================="
 echo ""
 
-[ -d ~/.kymsu/plugins.d -a -x ~/.kymsu/plugins.d ] && find ~/.kymsu/plugins.d -type f -name '*.sh' -perm +u+x -exec $SHELL {} ${1:no-cleanup} \;
+[ -d ~/.kymsu/plugins.d -a -x ~/.kymsu/plugins.d ] && find ~/.kymsu/plugins.d -type f -name '*.sh' -perm +u+x -exec bash -c {} ${1:no-cleanup} \;


### PR DESCRIPTION
Currently, plugin scripts in `~/.kymsu/plugins.d` directory are located only by filename extension.
File type and permission are ignored, so if a directory `foo.sh` was added in `~/.kymsu/plugins.d`, an error occurred.
Using `find` to check file type and permission resolve the problem, and there is two interesting side effect.
Firstly, to disable a plugin, just remove its executable permission.
And secondly, the `for` loop becoming useless, thanks to `-exec` option of `find`.

Moreover, with the current version of this script, if `~/.kymsu/plugins.d` does not exist, an error occurred.
So, i have added a check to verify that it exists, is a directory and is readable.

And… I'm not sure that run plugin script in a sub-shell is mandatory, so i have kept the call to `bash` to run it.