### PR TITLE
Use portable shebang.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Make Kymsu accessible in PATH
 ln -s `pwd`/kymsu.sh /usr/local/bin/kymsu

--- a/kymsu.sh
+++ b/kymsu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "Please, grab a ☕️ , KYMSU keep your working environment up to date!"
 echo "=============================================================="
 echo ""

--- a/plugins.d/00-kymsu.sh
+++ b/plugins.d/00-kymsu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "🦄  KYMSU self update"
 CURRENT=`pwd`
 cd `cat ~/.kymsu/path` && git pull

--- a/plugins.d/atom.sh
+++ b/plugins.d/atom.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "⚛️  Atom editor will be shiny when you'll be back from your coffee/tea break!"
 if hash apm-beta 2>/dev/null; then
     apm-beta upgrade -c false

--- a/plugins.d/composer.sh
+++ b/plugins.d/composer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if hash composer 2>/dev/null; then
   echo "🎼  Composer"
   composer global update

--- a/plugins.d/homebrew.sh
+++ b/plugins.d/homebrew.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "🍺  Homebrew"
 brew update
 brew upgrade

--- a/plugins.d/mas.sh
+++ b/plugins.d/mas.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "🍏  Mac App Store updates come fast as lightning"
 mas outdated
 echo ""

--- a/plugins.d/yarn.sh
+++ b/plugins.d/yarn.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if hash yarn 2>/dev/null; then
   echo "📦  Yet another Yarn upgrade running ..."
   yarn global upgrade

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -rf $(which kymsu)
 rm -rf ~/.kymsu


### PR DESCRIPTION
It's possible that `bash` is not located in `/bin`.
So using `#!/bin/bash` is bad practice and a more portable should be used. 