### PR TITLE
Tweak install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
+KYMSU_PATH=`pwd`
+
 # Make Kymsu accessible in PATH
-ln -s `pwd`/kymsu.sh /usr/local/bin/kymsu
+ln -fs "${KYMSU_PATH}"/kymsu.sh /usr/local/bin/kymsu
 
 # Store Kymsu stuff in home directory
-mkdir ~/.kymsu && echo "`pwd`" > ~/.kymsu/path
-cp -R `pwd`/plugins.d ~/.kymsu
+mkdir -p ~/.kymsu && echo "${KYMSU_PATH}" > ~/.kymsu/path
+cp -R "${KYMSU_PATH}/plugins.d" ~/.kymsu
 
 echo "KYMSU has been installed. Run kymsu command!"


### PR DESCRIPTION
* Allow kymsu symlink to be overwritten
* Write `path` file even if `~/.kymsu` directory exists

Both these changes fix issues that might occur if you move your
kymsu working copy and want to reinstall.

* Quote paths

This makes the install script work if the kymsu directory contains spaces.

This also fixes the problem mentioned in #22.