### PR TITLE
Use two spaces after icons

### DIFF
--- a/kymsu.sh
+++ b/kymsu.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-echo "Please, grab a ☕️ , KYMSU keep your working environment up to date!"
+echo "Please, grab a ☕️, KYMSU keep your working environment up to date!"
 
 MAX_WIDTH=50
 CURRENT_WIDTH=$(tput cols)

--- a/plugins.d/atom.sh
+++ b/plugins.d/atom.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-echo "⚛️  Atom editor will be shiny when you'll be back from your coffee/tea break!"
+echo "⚛️   Atom editor will be shiny when you'll be back from your coffee/tea break!"
 if hash apm-beta 2>/dev/null; then
     apm-beta upgrade -c false
 fi

--- a/plugins.d/npm.sh
+++ b/plugins.d/npm.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 if hash npm 2>/dev/null; then
-    echo "💊 Upgrade npm itself"
+    echo "💊  Upgrade npm itself"
     npm install npm@latest -g
     echo ""
 
-    echo "🔊 npm list global outdated"
+    echo "🔊  npm list global outdated"
     npm outdated -g --depth=0
     echo ""
 
-    echo "📦 npm upgrade running ..."
+    echo "📦  npm upgrade running ..."
     npm update -g
     echo ""
 


### PR DESCRIPTION
Except in a sentence (grab a ☕️)
The "⚛️" icon needs 3 spaces to line up correctly