### PR TITLE
Ensure run order for plugins

### DIFF
--- a/kymsu.sh
+++ b/kymsu.sh
@@ -6,4 +6,4 @@ CURRENT_WIDTH=$(tput cols)
 COLUMNS=$(( CURRENT_WIDTH > MAX_WIDTH ? MAX_WIDTH : CURRENT_WIDTH ))
 printf '%*s\n' "${COLUMNS}" '' | tr ' ' =
 
-[ -d ~/.kymsu/plugins.d -a -x ~/.kymsu/plugins.d ] && find ~/.kymsu/plugins.d -type f -name '*.sh' -perm +u+x -exec bash -c {} ${1:no-cleanup} \;
+[ -d ~/.kymsu/plugins.d -a -x ~/.kymsu/plugins.d ] && find -s ~/.kymsu/plugins.d -type f -name '*.sh' -perm +u+x -exec bash -c {} ${1:no-cleanup} \;


### PR DESCRIPTION
Currently it's semi-random which order the update scripts are being run in.

Adding `-s` on `find` forces it to traverse in lexicographical order, meaning that `00-...` comes before `10-...` which will come before `20-...` etc.
