### PR TITLE
Clean npm cache only if npm version less than 5.0.0

### DIFF
--- a/plugins.d/npm.sh
+++ b/plugins.d/npm.sh
@@ -19,7 +19,7 @@ if hash npm 2>/dev/null; then
       fi
     fi
 
-    echo "🌬   Verifying npm cache"
+    echo "🔍   Verifying npm cache"
     npm cache verify
 
     echo "🌬   Running npm health check"

--- a/plugins.d/npm.sh
+++ b/plugins.d/npm.sh
@@ -12,8 +12,16 @@ if hash npm 2>/dev/null; then
     npm update -g
     echo ""
 
-  if [[ $1 == "cleanup" ]]; then
-    echo "🌬  Cleaning npm cache"
-    npm cache clean
-  fi
+    if [[ $1 == "cleanup" ]]; then
+      if printf '%s\n%s\n' "$(npm --version)" 5.0.0 | sort --version-sort --check=silent; then
+        echo "🌬   Cleaning npm cache"
+        npm cache clean
+      fi
+    fi
+
+    echo "🌬   Verifying npm cache"
+    npm cache verify
+
+    echo "🌬   Running npm health check"
+    npm doctor
 fi

--- a/plugins.d/npm.sh
+++ b/plugins.d/npm.sh
@@ -22,6 +22,6 @@ if hash npm 2>/dev/null; then
     echo "🔍   Verifying npm cache"
     npm cache verify
 
-    echo "🌬   Running npm health check"
+    echo "👨‍⚕️   Running npm health check"
     npm doctor
 fi


### PR DESCRIPTION
With newer versions of npm, `npm cache clean` results in this error:
`As of npm@5, the npm cache self-heals from corruption issues and data extracted from the cache is guaranteed to be valid. If you want to make sure everything is consistent, use 'npm cache verify' instead. On the other hand, if you're debugging an issue with the installer, you can use `npm install --cache /tmp/empty-cache` to use a temporary cache instead of nuking the actual one`

From npm 5.0.0 release notes (https://github.com/npm/npm/releases/tag/v5.0.0):

A new npm cache verify command that will garbage collect your cache, reducing disk usage for things you don't need (-handwave-), and will do full integrity verification on both the index and the content. This is also hooked into npm doctor as part of its larger suite of checking tools.

The new cache is very fault tolerant and supports concurrent access.

Multiple npm processes will not corrupt a shared cache.
Corrupted data will not be installed. Data is checked on both insertion and extraction, and treated as if it were missing if found to be corrupted. I will literally bake you a cookie if you manage to corrupt the cache in such a way that you end up with the wrong data in your installation (installer bugs notwithstanding).
npm cache clear is no longer useful for anything except clearing up disk space.